### PR TITLE
Fix expected headers string

### DIFF
--- a/modules/default/utils.js
+++ b/modules/default/utils.js
@@ -115,9 +115,9 @@ const getExpectedResponseHeadersString = function (expectedResponseHeaders) {
 				expectedResponseHeadersString = `${expectedResponseHeadersString},${header}`;
 			}
 		}
-		return expectedResponseHeaders;
-	}
-	return undefined;
+                return expectedResponseHeadersString;
+        }
+        return undefined;
 };
 
 /**


### PR DESCRIPTION
## Summary
- fix utils to return correct expected headers string

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ceb977c483299e4bf0f3156ec0a6